### PR TITLE
商品の購入時、商品名を指定するだけで買えるようにした

### DIFF
--- a/vending_machine/spec/models/vending_machine_spec.rb
+++ b/vending_machine/spec/models/vending_machine_spec.rb
@@ -106,12 +106,12 @@ RSpec.describe 'VendingMachine', type: :model do
       end
 
       it "在庫を減らし、売上金額を減らす" do
-        expect(vending_machine.stocks_find_by_name('コーラ').count).to eq 5
+        expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 5
         expect(vending_machine.amount).to eq 0
 
         vending_machine.sell(drink)
 
-        expect(vending_machine.stocks_find_by_name('コーラ').count).to eq 4
+        expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 4
         expect(vending_machine.amount).to eq 120
       end
     end
@@ -126,12 +126,12 @@ RSpec.describe 'VendingMachine', type: :model do
         end
 
         it "在庫数も売上金額も変化しない" do
-          expect(vending_machine.stocks_find_by_name('コーラ').count).to eq 5
+          expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 5
           expect(vending_machine.amount).to eq 0
 
           expect(vending_machine.sell(cola)).to be nil
 
-          expect(vending_machine.stocks_find_by_name('コーラ').count).to eq 5
+          expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 5
           expect(vending_machine.amount).to eq 0
         end
       end
@@ -142,12 +142,12 @@ RSpec.describe 'VendingMachine', type: :model do
         end
 
         it "在庫数も売上金額も変化しない" do
-          expect(vending_machine.stocks_find_by_name('オレンジジュース').count).to eq 0
+          expect(vending_machine.stocks_find_by_name("オレンジジュース").count).to eq 0
           expect(vending_machine.amount).to eq 0
 
           expect(vending_machine.sell(orange_juice)).to be nil
 
-          expect(vending_machine.stocks_find_by_name('オレンジジュース').count).to eq 0
+          expect(vending_machine.stocks_find_by_name("オレンジジュース").count).to eq 0
           expect(vending_machine.amount).to eq 0
         end
       end

--- a/vending_machine/spec/models/vending_machine_spec.rb
+++ b/vending_machine/spec/models/vending_machine_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe 'VendingMachine', type: :model do
     end
   end
 
-
   describe "#sell" do
     context "購入したい商品に対し、在庫も投入金額も十分な場合" do
       let!(:drink) { Drink.new(name: "コーラ", price: 120) }
@@ -109,7 +108,7 @@ RSpec.describe 'VendingMachine', type: :model do
         expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 5
         expect(vending_machine.amount).to eq 0
 
-        vending_machine.sell(drink)
+        vending_machine.sell("コーラ")
 
         expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 4
         expect(vending_machine.amount).to eq 120
@@ -129,7 +128,7 @@ RSpec.describe 'VendingMachine', type: :model do
           expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 5
           expect(vending_machine.amount).to eq 0
 
-          expect(vending_machine.sell(cola)).to be nil
+          expect(vending_machine.sell("コーラ")).to be nil
 
           expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 5
           expect(vending_machine.amount).to eq 0

--- a/vending_machine/vending_machine.rb
+++ b/vending_machine/vending_machine.rb
@@ -1,4 +1,5 @@
 require_relative "./drink"
+require "pry"
 
 class VendingMachine
   ACCEPTABLE_MONEY = [10, 50, 100, 500, 1_000]
@@ -44,11 +45,11 @@ class VendingMachine
     @stocks << drink
   end
 
-  def sell(drink)
+  def sell(drink_name)
     # XXX 二段階で処理してるのでなんか微妙だけど、いい方法が他にあるのだろうか
     # XXX 在庫がなかったときの処理はまだ書いていない
-    if can_buy?(drink)
-      index = @stocks.find_index{|stock| stock.name == drink.name }
+    if can_buy?(drink_name)
+      index = @stocks.find_index{|stock| stock.name == drink_name }
       sold = @stocks.delete_at(index)
       @amount += sold.price
       @summary -= sold.price
@@ -61,7 +62,10 @@ class VendingMachine
     return money
   end
 
-  def can_buy?(drink)
+  def can_buy?(drink_name)
+    drink = @stocks.detect{|stock| stock.name == drink_name }
+    return false unless drink
+
     (@summary >= drink.price) && (stocks_find_by_name(drink.name).count > 0)
   end
 end


### PR DESCRIPTION
フィードバックより。
商品を買う人はその商品がいくらだかを「認知」する必要はある（お金の投入のため）が、いくらかを「指定」する必要はない。そのため、商品名だけを指定すれば購入できるように修正した。