### PR TITLE
#5 の修正漏れ

### DIFF
--- a/vending_machine/spec/models/vending_machine_spec.rb
+++ b/vending_machine/spec/models/vending_machine_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'VendingMachine', type: :model do
     context "飲み物の購入後" do
       it "現在の投入金額からジュース購入金額を引いた釣り銭を出力して、投入総計をゼロにする" do
         drink = Drink.new(name: "コーラ", price: 120)
-        vending_machine.sell(drink)
+        vending_machine.sell(drink.name)
 
         expect(vending_machine.refund).to eq 1_480
         expect(vending_machine.summary).to eq 0
@@ -87,8 +87,8 @@ RSpec.describe 'VendingMachine', type: :model do
 
       it "複数回購入しても、現在の投入金額からジュース購入金額を引いた釣り銭を出力して、投入総計をゼロにする" do
         drink = Drink.new(name: "コーラ", price: 120)
-        vending_machine.sell(drink)
-        vending_machine.sell(drink)
+        vending_machine.sell(drink.name)
+        vending_machine.sell(drink.name)
 
         expect(vending_machine.refund).to eq 1_360
         expect(vending_machine.summary).to eq 0
@@ -144,7 +144,7 @@ RSpec.describe 'VendingMachine', type: :model do
           expect(vending_machine.stocks_find_by_name("オレンジジュース").count).to eq 0
           expect(vending_machine.amount).to eq 0
 
-          expect(vending_machine.sell(orange_juice)).to be nil
+          expect(vending_machine.sell(orange_juice.name)).to be nil
 
           expect(vending_machine.stocks_find_by_name("オレンジジュース").count).to eq 0
           expect(vending_machine.amount).to eq 0


### PR DESCRIPTION
#5 の修正漏れ。Drink オブジェクトを渡す実装のままになってしまっているところがあったので、名前を渡す形に修正した。