### PR TITLE
ステップ5

### DIFF
--- a/spec/models/vending_machine_spec.rb
+++ b/spec/models/vending_machine_spec.rb
@@ -128,7 +128,9 @@ RSpec.describe "VendingMachine", type: :model do
       let!(:drink) { Drink.new(name: "コーラ", price: 120) }
 
       before do
-        vending_machine.input(1000)
+        vending_machine.input(100)
+        vending_machine.input(10)
+        vending_machine.input(10)
       end
 
       it "在庫を減らし、売上金額を減らす" do
@@ -139,6 +141,10 @@ RSpec.describe "VendingMachine", type: :model do
 
         expect(vending_machine.stocks_find_by_name("コーラ").count).to eq 4
         expect(vending_machine.amount).to eq 120
+      end
+
+      it "お釣りの金額が返される" do
+        expect(vending_machine.sell("コーラ")).to eq 0
       end
     end
 

--- a/spec/models/vending_machine_spec.rb
+++ b/spec/models/vending_machine_spec.rb
@@ -111,15 +111,6 @@ RSpec.describe "VendingMachine", type: :model do
         expect(vending_machine.refund).to eq 1_480
         expect(vending_machine.summary).to eq 0
       end
-
-      it "複数回購入しても、現在の投入金額からジュース購入金額を引いた釣り銭を出力して、投入総計をゼロにする" do
-        drink = Drink.new(name: "コーラ", price: 120)
-        vending_machine.sell(drink.name)
-        vending_machine.sell(drink.name)
-
-        expect(vending_machine.refund).to eq 1_360
-        expect(vending_machine.summary).to eq 0
-      end
     end
   end
 

--- a/spec/models/vending_machine_spec.rb
+++ b/spec/models/vending_machine_spec.rb
@@ -95,22 +95,10 @@ RSpec.describe "VendingMachine", type: :model do
       vending_machine.input(1000)
     end
 
-    context "飲み物の購入前" do
-      it "現在の投入金額を出力して、投入総計をゼロにする" do
-        expect(vending_machine.refund).to eq 1_600
+    it "現在の投入金額を出力して、投入総計をゼロにする" do
+      expect(vending_machine.refund).to eq 1_600
 
-        expect(vending_machine.summary).to eq 0
-      end
-    end
-
-    context "飲み物の購入後" do
-      it "現在の投入金額からジュース購入金額を引いた釣り銭を出力して、投入総計をゼロにする" do
-        drink = Drink.new(name: "コーラ", price: 120)
-        vending_machine.sell(drink.name)
-
-        expect(vending_machine.refund).to eq 1_480
-        expect(vending_machine.summary).to eq 0
-      end
+      expect(vending_machine.summary).to eq 0
     end
   end
 

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -33,10 +33,10 @@ class VendingMachine
   end
 
   def refund
-    summary = @summary
+    change = @summary
     @summary = 0
 
-    summary
+    change
   end
 
   def add_stocks(drinks)
@@ -51,6 +51,8 @@ class VendingMachine
       sold = @stocks.delete_at(index)
       @amount += sold.price
       @summary -= sold.price
+
+      refund
     end
   end
 


### PR DESCRIPTION
ジュース値段以上の投入金額が投入されている条件下で購入操作を行うと、釣り銭（投入金額とジュース値段の差分）を出力する。
  - ジュースと投入金額が同じ場合、つまり、釣り銭0円の場合も、釣り銭0円と出力する。
  - 釣り銭の硬貨の種類は考慮しなくてよい。
